### PR TITLE
Correctly show token spells when dealing with classes that both prepare and don't prepare spells

### DIFF
--- a/scripts/token_dropdown.js
+++ b/scripts/token_dropdown.js
@@ -131,9 +131,9 @@ function getData(targetActor) {
         let consumables = targetActor.data.items.filter(i => i.type == "consumable");
         let items = { "weapons": weapons, "equipment": equipment, "other": other, "consumables": consumables };
         
-        let preparedSpells = targetActor.data.items.find(i => ['Sorcerer', 'Warlock'].includes(i.name))
-            ? targetActor.data.items.filter(i => i.type == "spell")
-            : targetActor.data.items.filter(i => i.type == "spell" && i.data.preparation.prepared);
+        let preparedSpells = targetActor.data.items.find(i => ['artificer', 'cleric', 'druid', 'wizard', 'paladin'].includes(i.name.toLowerCase()))
+            ? targetActor.data.items.filter(i => i.type == "spell" && (i.data.preparation.prepared || i.data.preparation.mode === 'always' || i.data.level === 0))
+            : targetActor.data.items.filter(i => i.type == "spell");
         let spells = categoriseSpells(preparedSpells);
 
         let allFeats = targetActor.data.items.filter(i => i.type == "feat");


### PR DESCRIPTION
If character is a class that does not prepare spells, pull in all their spells.
If character is a class that prepares spells or is a multiclass that is a mixture, then pull in prepared, always prepared and cantrip spells.

Reason: When using my cleric/sorcerer character, only the prepared cleric spells were being pulled in, however sorcerer spells that were getting flagged as `always prepared` were not being pulled it.

Note that if a character that does not prepare skills is imported, none of their spells are marked as prepared/always prepared. This PR should cover all the above cases now.

Should actually fix https://github.com/Kekilla0/TokenBar/issues/9