### PR TITLE
Update title to match name

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
 	"name" : "TokenBar",
-	"title" : "Token Action Dropdown Bar",
+	"title" : "TokenBar",
 	"description" : "Creates Bar to Control a tokens actions.",
 	"author" : ["^ and stick#0520", "kekilla#7036"],
 	"version" : "0.1.0",


### PR DESCRIPTION
Installing TokenBar, then seeing it labeled as Token Action Dropdown Bar is confusing. With a ton of other modules, it also becomes hard to remember/find the different name. Updated title to stay consistent.